### PR TITLE
[Fix] serverless warning on schema

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -29,7 +29,7 @@ module.exports = {
         '^[a-zA-Z0-9-]+$': {
           type: 'object',
           properties: {
-            name: { type: 'boolean' },
+            name: { type: 'string' },
             image: { type: 'string' },
             executionRoleArn: { type: 'string' },
             taskRoleArn: { type: 'string' },


### PR DESCRIPTION
Current serverless cli versions will throw the following warning

<img width="755" alt="image" src="https://user-images.githubusercontent.com/7460917/162509087-9e3e1838-d703-473d-91de-2129c6154141.png">

This should fix that configuration warning.