### PR TITLE
Include provider environment variables within tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ provider:
   iamManagedPolicies:
     - arn:aws:iam::123456:policy/my-managed-provider-policy
 
+  # (optional) environment variables present within the provider are added to all tasks.
+  environment:
+    name: value
+
   # (optional) tags present within the provider are added to task resources.
   tags:
     name: value

--- a/example/serverless.yml
+++ b/example/serverless.yml
@@ -49,5 +49,3 @@ fargate:
         - /app/service.php
         - my-scheduled-task
         - 1
-
-functions:

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ class ServerlessFargate {
   async compileTasks() {
     const config = parse({
       ...this.config,
+      environment: this.getEnvironmentVariables(),
       tags: this.getResourceTags(),
       iamRoleStatements: this.getIamRoleStatements(),
       iamManagedPolicies: this.getIamManagedPolicies(),
@@ -101,6 +102,13 @@ class ServerlessFargate {
     return {
       ...(this.serverless.service.provider.tags || {}),
       ...(this.config.tags || {}),
+    };
+  }
+
+  getEnvironmentVariables() {
+    return {
+      ...(this.serverless.service.provider.environment || {}),
+      ...(this.config.environment || {}),
     };
   }
 }


### PR DESCRIPTION
This ensures that provider environment variables are included within the defined tasks. You can optionally still include/over-ride environment variables at the Fargate config. and task level.

Addresses: https://github.com/eddmann/serverless-fargate/issues/2