### PR TITLE
Update VPC configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ provider:
   environment:
     name: value
 
+  vpc:
+    # (optional) default security groups which are added to tasks that do not contain any overrides.
+    securityGroupIds:
+      - sg-12345
+
+    # (required) default subnets which are added to tasks that do not contain any overrides.
+    # all tasks MUST be assigned subnets as Fargate operates within `awsvpc` mode.
+    subnetIds:
+      - subnet-1234
+
   # (optional) tags present within the provider are added to task resources.
   tags:
     name: value
@@ -84,13 +94,13 @@ fargate:
     - arn:aws:iam::123456:policy/my-managed-task-policy
 
   vpc:
-    # (optional) default security groups you wish to apply to each task.
-    securityGroups:
+    # (optional) default security groups which are added to tasks that do not contain any overrides; these override any provider-level configuration.
+    securityGroupIds:
       - sg-12345
 
-    # (required) default subnets you wish to allocate the tasks within, either subnets are defined here or within each task.
+    # (required) default subnets which are added to tasks that do not contain any overrides; these override any provider-level configuration.
     # all tasks MUST be assigned subnets as Fargate operates within `awsvpc` mode.
-    subnets:
+    subnetIds:
       - subnet-1234
 
     # (optional) default flag to assign a public IP to each task, this requires the supplied subnets to be public (internet) facing.
@@ -115,13 +125,13 @@ fargate:
       taskRoleArn: arn:aws:iam::123456:role/my-custom-task-role
 
       vpc:
-        # (optional) security groups you wish to apply to the given tasks, this overrides any default security groups supplied.
-        securityGroups:
+        # (optional) security groups you wish to apply to the given tasks; these override any provider/fargate-level configuration.
+        securityGroupIds:
           - sg-12345
 
-        # (required) subnets you wish to allocate the given task within, either subnets are defined here or at the global `vpc` level.
+        # (required) subnets you wish to apply to the given tasks; these override any provider/fargate-level configuration.
         # all tasks MUST be assigned subnets as Fargate operates within `awsvpc` mode.
-        subnets:
+        subnetIds:
           - subnet-1234
 
         # (optional) flag to assign a public IP to the given task, this requires the supplied subnets to be public (internet) facing.

--- a/example/vpc.yml.example
+++ b/example/vpc.yml.example
@@ -1,4 +1,4 @@
-securityGroups:
+securityGroupIds:
   - sg-1234
-subnets:
+subnetIds:
   - subnet-1234

--- a/src/__tests__/__snapshots__/parser.test.js.snap
+++ b/src/__tests__/__snapshots__/parser.test.js.snap
@@ -55,10 +55,10 @@ Object {
       "taskRoleArn": "arn:aws:iam::123456:role/my-custom-task-role-for-task-1",
       "vpc": Object {
         "assignPublicIp": true,
-        "securityGroups": Array [
+        "securityGroupIds": Array [
           "sg-5678",
         ],
-        "subnets": Array [
+        "subnetIds": Array [
           "subnet-5678",
         ],
       },
@@ -86,10 +86,10 @@ Object {
       "taskRoleArn": "arn:aws:iam::123456:role/my-custom-task-role",
       "vpc": Object {
         "assignPublicIp": false,
-        "securityGroups": Array [
+        "securityGroupIds": Array [
           "sg-1234",
         ],
-        "subnets": Array [
+        "subnetIds": Array [
           "subnet-1234",
         ],
       },
@@ -97,10 +97,10 @@ Object {
   ],
   "vpc": Object {
     "assignPublicIp": false,
-    "securityGroups": Array [
+    "securityGroupIds": Array [
       "sg-1234",
     ],
-    "subnets": Array [
+    "subnetIds": Array [
       "subnet-1234",
     ],
   },
@@ -133,10 +133,10 @@ Object {
       "taskRoleArn": undefined,
       "vpc": Object {
         "assignPublicIp": false,
-        "securityGroups": Array [
+        "securityGroupIds": Array [
           "sg-1234",
         ],
-        "subnets": Array [
+        "subnetIds": Array [
           "subnet-1234",
         ],
       },
@@ -144,10 +144,10 @@ Object {
   ],
   "vpc": Object {
     "assignPublicIp": false,
-    "securityGroups": Array [
+    "securityGroupIds": Array [
       "sg-1234",
     ],
-    "subnets": Array [
+    "subnetIds": Array [
       "subnet-1234",
     ],
   },
@@ -185,10 +185,10 @@ Object {
       "taskRoleArn": undefined,
       "vpc": Object {
         "assignPublicIp": false,
-        "securityGroups": Array [
+        "securityGroupIds": Array [
           "sg-1234",
         ],
-        "subnets": Array [
+        "subnetIds": Array [
           "subnet-1234",
         ],
       },
@@ -196,10 +196,10 @@ Object {
   ],
   "vpc": Object {
     "assignPublicIp": false,
-    "securityGroups": Array [
+    "securityGroupIds": Array [
       "sg-1234",
     ],
-    "subnets": Array [
+    "subnetIds": Array [
       "subnet-1234",
     ],
   },

--- a/src/__tests__/compiler.test.js
+++ b/src/__tests__/compiler.test.js
@@ -20,8 +20,8 @@ test('single service task', () => {
       ],
       iamManagedPolicies: ['arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess'],
       vpc: {
-        subnets: ['subnet-1234', 'subnet-5678'],
-        securityGroups: ['sg-1234'],
+        subnetIds: ['subnet-1234', 'subnet-5678'],
+        securityGroupIds: ['sg-1234'],
         assignPublicIp: false,
       },
       tags: {
@@ -32,8 +32,8 @@ test('single service task', () => {
           name: 'my-task',
           image: 'my-image',
           vpc: {
-            subnets: ['subnet-1234', 'subnet-5678'],
-            securityGroups: ['sg-1234'],
+            subnetIds: ['subnet-1234', 'subnet-5678'],
+            securityGroupIds: ['sg-1234'],
             assignPublicIp: false,
           },
           command: ['command'],
@@ -80,8 +80,8 @@ test('single scheduled task', () => {
       ],
       iamManagedPolicies: ['arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess'],
       vpc: {
-        subnets: ['subnet-1234', 'subnet-5678'],
-        securityGroups: ['sg-1234'],
+        subnetIds: ['subnet-1234', 'subnet-5678'],
+        securityGroupIds: ['sg-1234'],
         assignPublicIp: false,
       },
       tags: {
@@ -92,8 +92,8 @@ test('single scheduled task', () => {
           name: 'my-task',
           image: 'my-image',
           vpc: {
-            subnets: ['subnet-1234', 'subnet-5678'],
-            securityGroups: ['sg-1234'],
+            subnetIds: ['subnet-1234', 'subnet-5678'],
+            securityGroupIds: ['sg-1234'],
             assignPublicIp: false,
           },
           command: ['command'],
@@ -136,8 +136,8 @@ test('service and scheduled tasks', () => {
       ],
       iamManagedPolicies: ['arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess'],
       vpc: {
-        subnets: ['subnet-1234', 'subnet-5678'],
-        securityGroups: ['sg-1234'],
+        subnetIds: ['subnet-1234', 'subnet-5678'],
+        securityGroupIds: ['sg-1234'],
         assignPublicIp: false,
       },
       tags: {
@@ -148,8 +148,8 @@ test('service and scheduled tasks', () => {
           name: 'my-task-1',
           image: 'my-image-1',
           vpc: {
-            subnets: ['subnet-1234', 'subnet-5678'],
-            securityGroups: ['sg-1234'],
+            subnetIds: ['subnet-1234', 'subnet-5678'],
+            securityGroupIds: ['sg-1234'],
             assignPublicIp: false,
           },
           command: ['command'],
@@ -173,8 +173,8 @@ test('service and scheduled tasks', () => {
           name: 'my-task-2',
           image: 'my-image-2',
           vpc: {
-            subnets: ['subnet-1234', 'subnet-5678'],
-            securityGroups: ['sg-1234'],
+            subnetIds: ['subnet-1234', 'subnet-5678'],
+            securityGroupIds: ['sg-1234'],
             assignPublicIp: false,
           },
           command: ['command'],
@@ -206,8 +206,8 @@ test('definition without IAM statements/policies present', () => {
       iamRoleStatements: [],
       iamManagedPolicies: [],
       vpc: {
-        subnets: ['subnet-1234', 'subnet-5678'],
-        securityGroups: ['sg-1234'],
+        subnetIds: ['subnet-1234', 'subnet-5678'],
+        securityGroupIds: ['sg-1234'],
         assignPublicIp: false,
       },
       tags: {},

--- a/src/__tests__/parser.test.js
+++ b/src/__tests__/parser.test.js
@@ -3,8 +3,8 @@ const parse = require('../parser');
 test('minimal service task configuration', () => {
   const parsed = parse({
     vpc: {
-      securityGroups: ['sg-1234'],
-      subnets: ['subnet-1234'],
+      securityGroupIds: ['sg-1234'],
+      subnetIds: ['subnet-1234'],
     },
     tasks: {
       'my-task': {
@@ -19,8 +19,8 @@ test('minimal service task configuration', () => {
 test('minimal scheduled task configuration', () => {
   const parsed = parse({
     vpc: {
-      securityGroups: ['sg-1234'],
-      subnets: ['subnet-1234'],
+      securityGroupIds: ['sg-1234'],
+      subnetIds: ['subnet-1234'],
     },
     tasks: {
       'my-task': {
@@ -51,8 +51,8 @@ test('full service task configuration', () => {
     ],
     iamManagedPolicies: ['arn:aws:iam::aws:policy/my-managed-policy'],
     vpc: {
-      securityGroups: ['sg-1234'],
-      subnets: ['subnet-1234'],
+      securityGroupIds: ['sg-1234'],
+      subnetIds: ['subnet-1234'],
       assignPublicIp: false,
     },
     tags: {
@@ -66,8 +66,8 @@ test('full service task configuration', () => {
           'arn:aws:iam::123456:role/my-custom-execution-role-for-task-1',
         taskRoleArn: 'arn:aws:iam::123456:role/my-custom-task-role-for-task-1',
         vpc: {
-          securityGroups: ['sg-5678'],
-          subnets: ['subnet-5678'],
+          securityGroupIds: ['sg-5678'],
+          subnetIds: ['subnet-5678'],
           assignPublicIp: true,
         },
         command: ['command'],

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -149,8 +149,8 @@ const compileScheduledTask = (identifier, task) => ({
           NetworkConfiguration: {
             AwsVpcConfiguration: {
               AssignPublicIp: task.vpc.assignPublicIp ? 'ENABLED' : 'DISABLED',
-              SecurityGroups: task.vpc.securityGroups,
-              Subnets: task.vpc.subnets,
+              SecurityGroups: task.vpc.securityGroupIds,
+              Subnets: task.vpc.subnetIds,
             },
           },
         },
@@ -179,8 +179,8 @@ const compileService = (identifier, task) => ({
     NetworkConfiguration: {
       AwsvpcConfiguration: {
         AssignPublicIp: task.vpc.assignPublicIp ? 'ENABLED' : 'DISABLED',
-        SecurityGroups: task.vpc.securityGroups,
-        Subnets: task.vpc.subnets,
+        SecurityGroups: task.vpc.securityGroupIds,
+        Subnets: task.vpc.subnetIds,
       },
     },
     PropagateTags: 'TASK_DEFINITION',

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ class ServerlessFargate {
     const config = parse({
       ...this.config,
       environment: this.getEnvironmentVariables(),
+      vpc: this.getVpcConfiguration(),
       tags: this.getResourceTags(),
       iamRoleStatements: this.getIamRoleStatements(),
       iamManagedPolicies: this.getIamManagedPolicies(),
@@ -109,6 +110,13 @@ class ServerlessFargate {
     return {
       ...(this.serverless.service.provider.environment || {}),
       ...(this.config.environment || {}),
+    };
+  }
+
+  getVpcConfiguration() {
+    return {
+      ...(this.serverless.service.provider.vpc || {}),
+      ...(this.config.vpc || {}),
     };
   }
 }

--- a/src/parser.js
+++ b/src/parser.js
@@ -9,11 +9,11 @@ const parseTask = (global, name, task) => {
     executionRoleArn: task.executionRoleArn || global.executionRoleArn,
     taskRoleArn: task.taskRoleArn || global.taskRoleArn,
     vpc: {
-      subnets: get(task, 'vpc.subnets', global.vpc.subnets),
-      securityGroups: get(
+      subnetIds: get(task, 'vpc.subnetIds', global.vpc.subnetIds),
+      securityGroupIds: get(
         task,
-        'vpc.securityGroups',
-        global.vpc.securityGroups
+        'vpc.securityGroupIds',
+        global.vpc.securityGroupIds
       ),
       assignPublicIp: get(
         task,
@@ -71,8 +71,8 @@ module.exports = config => {
     iamManagedPolicies: config.iamManagedPolicies || [],
     logGroupName: config.logGroupName,
     vpc: {
-      subnets: get(config, 'vpc.subnets', []),
-      securityGroups: get(config, 'vpc.securityGroups', []),
+      subnetIds: get(config, 'vpc.subnetIds', []),
+      securityGroupIds: get(config, 'vpc.securityGroupIds', []),
       assignPublicIp: get(config, 'vpc.assignPublicIp', false),
     },
     tags: config.tags || {},

--- a/src/schema.js
+++ b/src/schema.js
@@ -13,8 +13,8 @@ module.exports = {
     vpc: {
       type: 'object',
       properties: {
-        securityGroups: { type: 'array', items: { type: 'string' } },
-        subnets: { type: 'array', items: { type: 'string' } },
+        securityGroupIds: { type: 'array', items: { type: 'string' } },
+        subnetIds: { type: 'array', items: { type: 'string' } },
         assignPublicIp: { type: 'boolean' },
       },
     },
@@ -37,11 +37,11 @@ module.exports = {
             vpc: {
               type: 'object',
               properties: {
-                securityGroups: {
+                securityGroupIds: {
                   type: 'array',
                   items: { type: 'string' },
                 },
-                subnets: { type: 'array', items: { type: 'string' } },
+                subnetIds: { type: 'array', items: { type: 'string' } },
                 assignPublicIp: { type: 'boolean' },
               },
             },


### PR DESCRIPTION
This aligns the `securityGroupIds` and `subnetIds` keys with how Serverless defines them.
It also defaults to using the provider defined VPC configuration if one is present.

Addresses: https://github.com/eddmann/serverless-fargate/issues/4