### PR TITLE
Fix new IAM role statements configuration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ class ServerlessFargate {
   getIamRoleStatements() {
     const providerStatements = get(
       this.serverless.service.provider,
-      'iam.role.statement',
+      'iam.role.statements',
       []
     );
 


### PR DESCRIPTION
Ensure we correctly look for the new means of specifying IAM role statements within Serverless config.