### PR TITLE
[Fix] Allow to use "!GetAtt" function for executionRoleArn & taskRoleArn.

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -6,8 +6,8 @@ module.exports = {
     memory: { type: 'string' },
     cpu: { type: 'integer', enum: [256, 512, 1024, 2048, 4096] },
     environment: { type: 'object' },
-    executionRoleArn: { type: 'string' },
-    taskRoleArn: { type: 'string' },
+    executionRoleArn: { type: 'object' },
+    taskRoleArn: { type: 'object' },
     logGroupName: { type: 'string' },
     iamRoleStatements: { type: 'array' },
     iamManagedPolicies: { type: 'array', items: { type: 'string' } },
@@ -33,8 +33,8 @@ module.exports = {
           properties: {
             name: { type: 'string' },
             image: { type: 'string' },
-            executionRoleArn: { type: 'string' },
-            taskRoleArn: { type: 'string' },
+            executionRoleArn: { type: 'object' },
+            taskRoleArn: { type: 'object' },
             vpc: {
               type: 'object',
               properties: {


### PR DESCRIPTION
ex)
```yaml
executionRoleArn: !GetAtt ECSTaskExecutionRole.Arn
```