### PR TITLE
add support for dependsOn

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -176,6 +176,7 @@ const compileScheduledTask = (identifier, task) => ({
 
 const compileService = (identifier, task) => ({
   Type: 'AWS::ECS::Service',
+  DependsOn: task.dependsOn,
   Properties: {
     Cluster: { 'Fn::Sub': '${FargateTasksCluster}' },
     ServiceName: task.name,

--- a/src/parser.js
+++ b/src/parser.js
@@ -5,6 +5,7 @@ const { get } = require('./util');
 const parseTask = (global, name, task) => {
   const definition = {
     name: task.name || name,
+    dependsOn: task.dependsOn || [],
     image: task.image,
     executionRoleArn: task.executionRoleArn || global.executionRoleArn,
     taskRoleArn: task.taskRoleArn || global.taskRoleArn,


### PR DESCRIPTION
In a common ECS + load balancer situation, the load balancer listener must be created before the service, otherwise an error like the one below occurs:

`Invalid request provided: CreateService error: The target group with targetGroupArn <ARN> does not have an associated load balancer.`

See also https://stackoverflow.com/questions/53971873/the-target-group-does-not-have-an-associated-load-balancer