### PR TITLE
Add config to control log retention

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -34,6 +34,7 @@ const compileCluster = config => ({
       Type: 'AWS::Logs::LogGroup',
       Properties: {
         LogGroupName: config.logGroupName,
+        RetentionInDays: config.logRetentionInDays,
         Tags: toTags(config.tags),
       },
     },

--- a/src/parser.js
+++ b/src/parser.js
@@ -88,6 +88,7 @@ module.exports = config => {
     iamRoleStatements: config.iamRoleStatements || [],
     iamManagedPolicies: config.iamManagedPolicies || [],
     logGroupName: config.logGroupName,
+    logRetentionInDays: config.logRetentionInDays,
     vpc: {
       subnetIds: get(config, 'vpc.subnetIds', []),
       securityGroupIds: get(config, 'vpc.securityGroupIds', []),

--- a/src/schema.js
+++ b/src/schema.js
@@ -10,6 +10,7 @@ module.exports = {
     executionRoleArn: { type: 'string' },
     taskRoleArn: { type: 'string' },
     logGroupName: { type: 'string' },
+    logRetentionInDays: { type: 'integer', enum: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 2192, 2557, 2922, 3288, 3653] },
     iamRoleStatements: { type: 'array' },
     iamManagedPolicies: { type: 'array', items: { type: 'string' } },
     vpc: {


### PR DESCRIPTION
Currently all the logs are retained indefninitly. This PR adds an optional `logRetentionInDays` config to control the retention period.