### PR TITLE
add support for volumes

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -139,6 +139,7 @@ const compileTaskDefinition = (images, task) => ({
     RuntimePlatform: task.architecture && {
       CpuArchitecture: task.architecture,
     },
+    Volumes: task.volumes,
     Tags: toTags(task.tags),
     ...task.cloudFormationResource.task,
   },

--- a/src/parser.js
+++ b/src/parser.js
@@ -22,6 +22,7 @@ const parseTask = (global, name, task) => {
         global.vpc.assignPublicIp
       ),
     },
+    volumes: task.volumes || [],
     command: task.command || [],
     entryPoint: task.entryPoint || [],
     memory: task.memory || global.memory,

--- a/src/schema.js
+++ b/src/schema.js
@@ -82,6 +82,10 @@ module.exports = {
             environment: { type: 'object' },
             tags: { type: 'object' },
             dependsOn: { type: 'array', items: { type: 'string' } },
+            volumes: {
+              type: 'array', 
+              items: { anyOf: [{ type: 'object' }, { type: 'string' }] }
+              },
             service: {
               type: 'object',
               properties: {


### PR DESCRIPTION
The "volumes" configuration does not have an associated schema, so it does not appear in the generated Cloudformation template. This PR adds a schema for "volumes".