### PR TITLE
Implement option to specify additional containers

### DIFF
--- a/src/__tests__/__snapshots__/parser.test.js.snap
+++ b/src/__tests__/__snapshots__/parser.test.js.snap
@@ -106,6 +106,9 @@ Object {
         "container": Object {
           "StopTimeout": 5,
         },
+        "additionalContainer": Object {
+          "Name": "additional-container-name",
+        },
         "service": Object {
           "EnableECSManagedTags": "true",
         },

--- a/src/__tests__/parser.test.js
+++ b/src/__tests__/parser.test.js
@@ -111,6 +111,11 @@ test('full service task configuration', () => {
           container: {
             StartTimeout: 5,
           },
+          additionalContainers: [
+            {
+              Name: 'additional-container-name'
+            }
+          ],
           service: {
             LoadBalancers: {
               ContainerName: 'container-name',

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -124,6 +124,7 @@ const compileTaskDefinition = (images, task) => ({
         },
         ...task.cloudFormationResource.container,
       },
+      ...task.cloudFormationResource.additionalContainers,
     ],
     Family: task.name,
     NetworkMode: 'awsvpc',

--- a/src/parser.js
+++ b/src/parser.js
@@ -41,6 +41,10 @@ const parseTask = (global, name, task) => {
         ...global.cloudFormationResource.container,
         ...get(task, 'cloudFormationResource.container', {}),
       },
+      additionalContainers: {
+        ...global.cloudFormationResource.additionalContainers,
+        ...get(task, 'cloudFormationResource.additionalContainers', {}),
+      },
       service: {
         ...global.cloudFormationResource.service,
         ...get(task, 'cloudFormationResource.service', {}),
@@ -99,6 +103,7 @@ module.exports = config => {
     cloudFormationResource: {
       task: get(config, 'cloudFormationResource.task', {}),
       container: get(config, 'cloudFormationResource.container', {}),
+      additionalContainers: get(config, 'cloudFormationResource.additionalContainers', []),
       service: get(config, 'cloudFormationResource.service', {}),
     },
   };

--- a/src/schema.js
+++ b/src/schema.js
@@ -45,6 +45,7 @@ module.exports = {
       properties: {
         task: { type: 'object' },
         container: { type: 'object' },
+        additionalContainer: { type: 'array' },
         service: { type: 'object' },
       },
     },


### PR DESCRIPTION
This is required to deploy sidecar containers, e.g. logging agents/ forwarders/ firelens