### PR TITLE
Add support for portMappings

### DIFF
--- a/src/__tests__/__snapshots__/compiler.test.js.snap
+++ b/src/__tests__/__snapshots__/compiler.test.js.snap
@@ -296,6 +296,17 @@ Object {
               },
             },
             "Name": "my-task-1",
+            "PortMappings": Array [
+              Object {
+                "containerPort": 5349,
+                "hostPort": 5349,
+                "protocol": "tcp",
+              },
+              Object {
+                "containerPortRange": "10000-20000",
+                "protocol": "udp",
+              },
+            ],
             "StopTimeout": 5,
           },
           Object {
@@ -403,6 +414,7 @@ Object {
               },
             },
             "Name": "my-task-2",
+            "PortMappings": undefined,
           },
         ],
         "Cpu": 256,
@@ -633,6 +645,7 @@ Object {
               },
             },
             "Name": "my-task",
+            "PortMappings": undefined,
           },
         ],
         "Cpu": 256,
@@ -860,6 +873,7 @@ Object {
               },
             },
             "Name": "my-task",
+            "PortMappings": undefined,
           },
         ],
         "Cpu": 256,

--- a/src/__tests__/__snapshots__/parser.test.js.snap
+++ b/src/__tests__/__snapshots__/parser.test.js.snap
@@ -95,6 +95,17 @@ Object {
       "image": "my-image-1",
       "memory": "2GB",
       "name": "my-task-1",
+      "portMappings": Array [
+        Object {
+          "containerPort": 5349,
+          "hostPort": 5349,
+          "protocol": "tcp",
+        },
+        Object {
+          "containerPortRange": "10000-20000",
+          "protocol": "udp",
+        },
+      ],
       "service": Object {
         "desiredCount": 2,
         "maximumPercent": 100,
@@ -146,6 +157,7 @@ Object {
       "image": "my-image-2",
       "memory": "1GB",
       "name": "task-2",
+      "portMappings": Array [],
       "service": Object {
         "desiredCount": 1,
         "maximumPercent": 200,
@@ -218,6 +230,7 @@ Object {
       "image": "my-image",
       "memory": "0.5GB",
       "name": "my-task",
+      "portMappings": Array [],
       "schedule": "rate(1 minute)",
       "tags": Object {},
       "taskRoleArn": undefined,
@@ -283,6 +296,7 @@ Object {
       "image": "my-image",
       "memory": "0.5GB",
       "name": "my-task",
+      "portMappings": Array [],
       "service": Object {
         "desiredCount": 1,
         "maximumPercent": 200,

--- a/src/__tests__/compiler.test.js
+++ b/src/__tests__/compiler.test.js
@@ -198,6 +198,17 @@ test('service and scheduled tasks', () => {
           memory: '0.5GB',
           cpu: 256,
           architecture: 'ARM64',
+          portMappings: [
+            {
+              containerPort: 5349,
+              hostPort: 5349,
+              protocol: "tcp"
+            },
+            {
+              containerPortRange: "10000-20000",
+              protocol: "udp",
+            }
+          ],
           environment: {
             task: 'variable',
           },

--- a/src/__tests__/parser.test.js
+++ b/src/__tests__/parser.test.js
@@ -98,6 +98,17 @@ test('full service task configuration', () => {
         memory: '2GB',
         cpu: 1024,
         architecture: 'ARM64',
+        portMappings: [
+          {
+            containerPort: 5349,
+            hostPort: 5349,
+            protocol: "tcp"
+          },
+          {
+            containerPortRange: "10000-20000",
+            protocol: "udp",
+          }
+        ],
         environment: {
           task: 'variable',
         },

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -112,6 +112,7 @@ const compileTaskDefinition = (images, task) => ({
         Environment: toEnvironment(task.environment),
         EntryPoint: task.entryPoint,
         Command: task.command,
+        PortMappings: task.portMappings,
         LogConfiguration: {
           LogDriver: 'awslogs',
           Options: {

--- a/src/parser.js
+++ b/src/parser.js
@@ -27,6 +27,7 @@ const parseTask = (global, name, task) => {
     memory: task.memory || global.memory,
     cpu: task.cpu || global.cpu,
     architecture: task.architecture || global.architecture,
+    portMappings: task.portMappings || [],
     environment: {
       ...global.environment,
       ...(task.environment || {}),

--- a/src/schema.js
+++ b/src/schema.js
@@ -7,6 +7,27 @@ module.exports = {
     memory: { type: 'string' },
     cpu: { type: 'integer', enum: [256, 512, 1024, 2048, 4096] },
     architecture: { type: 'string', enum: ['X86_64', 'ARM64'] },
+    portMappings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        'properties': {
+          "containerPort": {
+            type: 'number'
+          },
+          "hostPort": {
+            type: 'number'
+          },
+          "protocol": {
+            type: 'string',
+            enum: ['udp', 'tcp']
+          },
+          "containerPortRange": {
+            type: 'string'
+          },
+        }
+      }
+    },
     environment: { type: 'object' },
     executionRoleArn: { anyOf: [{ type: 'object' }, { type: 'string' }] },
     taskRoleArn: { anyOf: [{ type: 'object' }, { type: 'string' }] },


### PR DESCRIPTION
Add support for [portMappings](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinition.html#cfn-ecs-taskdefinition-containerdefinition-portmappings) as part of the `AWS::ECS::TaskDefinition`.

Verification:
* Updated unit tests and added `portMappings`.
* Used this branch with my projects `serverless.yml` to successfully deploy a task with the correct exposed ports.
```
  tasks:
    my-task:
      image: my-image
      memory: "0.5GB"
      cpu: 256
      architecture: ARM64
      portMappings:
        - containerPort: 3478
          hostPort: 3478
          protocol: "udp"
        - containerPortRange: "10000-20000"
          protocol: "udp"
```
<img width="911" alt="Screenshot 2023-07-20 at 11 59 49 AM" src="https://github.com/eddmann/serverless-fargate/assets/127768277/53813023-5608-4c28-b435-b68b3916bfe6">
