### PR TITLE
Skip role creation when custom ARNs provided

### DIFF
--- a/src/__tests__/__snapshots__/compiler.test.js.snap
+++ b/src/__tests__/__snapshots__/compiler.test.js.snap
@@ -2,7 +2,18 @@
 
 exports[`definition without IAM statements/policies present 1`] = `
 Object {
-  "Outputs": Object {},
+  "Outputs": Object {
+    "MytaskServiceArn": Object {
+      "Value": Object {
+        "Ref": "MytaskService",
+      },
+    },
+    "MytaskTaskArn": Object {
+      "Value": Object {
+        "Ref": "MytaskTask",
+      },
+    },
+  },
   "Resources": Object {
     "FargateIamExecutionRole": Object {
       "Properties": Object {
@@ -74,6 +85,86 @@ Object {
         "Tags": Array [],
       },
       "Type": "AWS::Logs::LogGroup",
+    },
+    "MytaskService": Object {
+      "DependsOn": undefined,
+      "Properties": Object {
+        "CapacityProviderStrategy": Array [
+          Object {
+            "CapacityProvider": "FARGATE",
+            "Weight": 1,
+          },
+        ],
+        "Cluster": Object {
+          "Fn::Sub": "\${FargateTasksCluster}",
+        },
+        "DeploymentConfiguration": Object {
+          "MaximumPercent": undefined,
+          "MinimumHealthyPercent": undefined,
+        },
+        "DesiredCount": 1,
+        "NetworkConfiguration": Object {
+          "AwsvpcConfiguration": Object {
+            "AssignPublicIp": "DISABLED",
+            "SecurityGroups": Array [
+              "sg-1234",
+            ],
+            "Subnets": Array [
+              "subnet-1234",
+              "subnet-5678",
+            ],
+          },
+        },
+        "PropagateTags": "TASK_DEFINITION",
+        "ServiceName": "my-task",
+        "Tags": Array [],
+        "TaskDefinition": Object {
+          "Fn::Sub": "\${MytaskTask}",
+        },
+      },
+      "Type": "AWS::ECS::Service",
+    },
+    "MytaskTask": Object {
+      "DependsOn": undefined,
+      "Properties": Object {
+        "ContainerDefinitions": Array [
+          Object {
+            "Command": Array [],
+            "EntryPoint": Array [],
+            "Environment": Array [],
+            "Image": undefined,
+            "LogConfiguration": Object {
+              "LogDriver": "awslogs",
+              "Options": Object {
+                "awslogs-group": Object {
+                  "Fn::Sub": "\${FargateTasksLogGroup}",
+                },
+                "awslogs-region": Object {
+                  "Fn::Sub": "\${AWS::Region}",
+                },
+                "awslogs-stream-prefix": "fargate",
+              },
+            },
+            "Name": "my-task",
+          },
+        ],
+        "Cpu": 256,
+        "ExecutionRoleArn": Object {
+          "Fn::Sub": "\${FargateIamExecutionRole}",
+        },
+        "Family": "my-task",
+        "Memory": "0.5GB",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": Array [
+          "FARGATE",
+        ],
+        "RuntimePlatform": undefined,
+        "Tags": Array [],
+        "TaskRoleArn": Object {
+          "Fn::Sub": "\${FargateIamTaskRole}",
+        },
+      },
+      "Type": "AWS::ECS::TaskDefinition",
     },
   },
 }

--- a/src/__tests__/compiler.test.js
+++ b/src/__tests__/compiler.test.js
@@ -264,7 +264,9 @@ test('service and scheduled tasks', () => {
 
 test('definition without IAM statements/policies present', () => {
   const compiled = compile(
-    {},
+    {
+      'my-image': 'image-uri',
+    },
     {
       clusterName: undefined,
       containerInsights: undefined,
@@ -280,7 +282,37 @@ test('definition without IAM statements/policies present', () => {
         assignPublicIp: false,
       },
       tags: {},
-      tasks: [],
+      cloudFormationResource: {
+        task: {},
+        container: {},
+        additionalContainers: [],
+        service: {},
+      },
+      tasks: [
+        {
+          name: 'my-task',
+          image: 'my-image',
+          vpc: {
+            subnetIds: ['subnet-1234', 'subnet-5678'],
+            securityGroupIds: ['sg-1234'],
+          },
+          command: [],
+          entryPoint: [],
+          memory: '0.5GB',
+          cpu: 256,
+          environment: {},
+          tags: {},
+          service: {
+            desiredCount: 1,
+          },
+          cloudFormationResource: {
+            task: {},
+            container: {},
+            additionalContainers: [],
+            service: {},
+          },
+        },
+      ],
     }
   );
 
@@ -289,4 +321,220 @@ test('definition without IAM statements/policies present', () => {
   expect(role.ManagedPolicyArns).toEqual([]);
 
   expect(compiled).toMatchSnapshot();
+});
+
+test('service task with custom IAM roles', () => {
+  const compiled = compile(
+    {
+      'my-image': 'image-uri',
+    },
+    {
+      memory: '0.5GB',
+      cpu: 256,
+      vpc: {
+        subnetIds: ['subnet-1234', 'subnet-5678'],
+        securityGroupIds: ['sg-1234'],
+      },
+      tags: {},
+      environment: {},
+      cloudFormationResource: {
+        task: {},
+        container: {},
+        additionalContainers: [],
+        service: {},
+      },
+      iamRoleStatements: [],
+      iamManagedPolicies: [],
+      tasks: [
+        {
+          name: 'my-task',
+          image: 'my-image',
+          executionRoleArn: 'arn:aws:iam::123456789:role/CustomExecutionRole',
+          taskRoleArn: 'arn:aws:iam::123456789:role/CustomTaskRole',
+          vpc: {
+            subnetIds: ['subnet-1234', 'subnet-5678'],
+            securityGroupIds: ['sg-1234'],
+          },
+          memory: '0.5GB',
+          cpu: 256,
+          service: {
+            desiredCount: 1,
+          },
+          tags: {},
+          environment: {},
+          cloudFormationResource: {
+            task: {},
+            container: {},
+            additionalContainers: [],
+            service: {},
+          },
+        },
+      ],
+    }
+  );
+
+  expect(compiled.Resources.FargateIamExecutionRole).toBeUndefined();
+  expect(compiled.Resources.FargateIamTaskRole).toBeUndefined();
+
+  expect(compiled.Resources.MytaskTask.Properties.ExecutionRoleArn).toEqual(
+    'arn:aws:iam::123456789:role/CustomExecutionRole'
+  );
+  expect(compiled.Resources.MytaskTask.Properties.TaskRoleArn).toEqual(
+    'arn:aws:iam::123456789:role/CustomTaskRole'
+  );
+});
+
+test('scheduled task with custom IAM roles', () => {
+  const compiled = compile(
+    {
+      'my-image': 'image-uri',
+    },
+    {
+      memory: '0.5GB',
+      cpu: 256,
+      vpc: {
+        subnetIds: ['subnet-1234', 'subnet-5678'],
+        securityGroupIds: ['sg-1234'],
+      },
+      tags: {},
+      environment: {},
+      cloudFormationResource: {
+        task: {},
+        container: {},
+        additionalContainers: [],
+        service: {},
+      },
+      iamRoleStatements: [],
+      iamManagedPolicies: [],
+      tasks: [
+        {
+          name: 'my-task',
+          image: 'my-image',
+          executionRoleArn: 'arn:aws:iam::123456789:role/CustomExecutionRole',
+          taskRoleArn: 'arn:aws:iam::123456789:role/CustomTaskRole',
+          vpc: {
+            subnetIds: ['subnet-1234', 'subnet-5678'],
+            securityGroupIds: ['sg-1234'],
+          },
+          memory: '0.5GB',
+          cpu: 256,
+          schedule: 'rate(1 minute)',
+          tags: {},
+          environment: {},
+          cloudFormationResource: {
+            task: {},
+            container: {},
+            additionalContainers: [],
+            service: {},
+          },
+        },
+      ],
+    }
+  );
+
+  expect(compiled.Resources.FargateIamExecutionRole).toBeUndefined();
+  expect(compiled.Resources.FargateIamTaskRole).toBeUndefined();
+
+  expect(compiled.Resources.MytaskTask.Properties.ExecutionRoleArn).toEqual(
+    'arn:aws:iam::123456789:role/CustomExecutionRole'
+  );
+  expect(compiled.Resources.MytaskTask.Properties.TaskRoleArn).toEqual(
+    'arn:aws:iam::123456789:role/CustomTaskRole'
+  );
+  expect(
+    compiled.Resources.MytaskScheduledTask.Properties.Targets[0].RoleArn
+  ).toEqual('arn:aws:iam::123456789:role/CustomExecutionRole');
+});
+
+test('mixed scenario - some tasks with custom roles, some without', () => {
+  const compiled = compile(
+    {
+      'my-image': 'image-uri',
+    },
+    {
+      memory: '0.5GB',
+      cpu: 256,
+      vpc: {
+        subnetIds: ['subnet-1234', 'subnet-5678'],
+        securityGroupIds: ['sg-1234'],
+      },
+      tags: {},
+      environment: {},
+      cloudFormationResource: {
+        task: {},
+        container: {},
+        additionalContainers: [],
+        service: {},
+      },
+      iamRoleStatements: [],
+      iamManagedPolicies: [],
+      tasks: [
+        {
+          name: 'task-with-role',
+          image: 'my-image',
+          executionRoleArn: 'arn:aws:iam::123456789:role/CustomExecutionRole',
+          taskRoleArn: 'arn:aws:iam::123456789:role/CustomTaskRole',
+          vpc: {
+            subnetIds: ['subnet-1234', 'subnet-5678'],
+            securityGroupIds: ['sg-1234'],
+          },
+          memory: '0.5GB',
+          cpu: 256,
+          service: {
+            desiredCount: 1,
+          },
+          tags: {},
+          environment: {},
+          cloudFormationResource: {
+            task: {},
+            container: {},
+            additionalContainers: [],
+            service: {},
+          },
+        },
+        {
+          name: 'task-without-role',
+          image: 'my-image',
+          vpc: {
+            subnetIds: ['subnet-1234', 'subnet-5678'],
+            securityGroupIds: ['sg-1234'],
+          },
+          memory: '0.5GB',
+          cpu: 256,
+          service: {
+            desiredCount: 1,
+          },
+          tags: {},
+          environment: {},
+          cloudFormationResource: {
+            task: {},
+            container: {},
+            additionalContainers: [],
+            service: {},
+          },
+        },
+      ],
+    }
+  );
+
+  expect(compiled.Resources.FargateIamExecutionRole).toBeDefined();
+  expect(compiled.Resources.FargateIamTaskRole).toBeDefined();
+
+  expect(
+    compiled.Resources.TaskwithroleTask.Properties.ExecutionRoleArn
+  ).toEqual('arn:aws:iam::123456789:role/CustomExecutionRole');
+  expect(compiled.Resources.TaskwithroleTask.Properties.TaskRoleArn).toEqual(
+    'arn:aws:iam::123456789:role/CustomTaskRole'
+  );
+
+  expect(
+    compiled.Resources.TaskwithoutroleTask.Properties.ExecutionRoleArn
+  ).toEqual({
+    'Fn::Sub': '${FargateIamExecutionRole}',
+  });
+  expect(compiled.Resources.TaskwithoutroleTask.Properties.TaskRoleArn).toEqual(
+    {
+      'Fn::Sub': '${FargateIamTaskRole}',
+    }
+  );
 });


### PR DESCRIPTION
- Handles mixed configurations by creating shared roles only for tasks that need them, while allowing custom ARNs to override on a per-task basis.
- Fixes scheduled tasks to use custom executionRoleArn in EventBridge rule targets.

This addresses issues raised in https://github.com/eddmann/serverless-fargate/issues/57