### PR TITLE
Support standalone task definitions without services

### DIFF
--- a/src/__tests__/__snapshots__/compiler.test.js.snap
+++ b/src/__tests__/__snapshots__/compiler.test.js.snap
@@ -888,3 +888,182 @@ Object {
   },
 }
 `;
+
+exports[`single standalone task 1`] = `
+Object {
+  "Outputs": Object {
+    "MytaskTaskArn": Object {
+      "Value": Object {
+        "Ref": "MytaskTask",
+      },
+    },
+  },
+  "Resources": Object {
+    "FargateIamExecutionRole": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Array [
+                  "ecs-tasks.amazonaws.com",
+                  "events.amazonaws.com",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+          "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceEventsRole",
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "provider",
+            "Value": "tag",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "FargateIamTaskRole": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Array [
+                  "ecs-tasks.amazonaws.com",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess",
+        ],
+        "Policies": Array [
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "sqs:*",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "FargateTaskPolicy",
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "provider",
+            "Value": "tag",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "FargateTasksCluster": Object {
+      "Properties": Object {
+        "CapacityProviders": Array [
+          "FARGATE",
+          "FARGATE_SPOT",
+        ],
+        "ClusterName": undefined,
+        "ClusterSettings": undefined,
+        "Tags": Array [
+          Object {
+            "Key": "provider",
+            "Value": "tag",
+          },
+        ],
+      },
+      "Type": "AWS::ECS::Cluster",
+    },
+    "FargateTasksLogGroup": Object {
+      "Properties": Object {
+        "LogGroupName": undefined,
+        "RetentionInDays": undefined,
+        "Tags": Array [
+          Object {
+            "Key": "provider",
+            "Value": "tag",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+    },
+    "MytaskTask": Object {
+      "DependsOn": undefined,
+      "Properties": Object {
+        "ContainerDefinitions": Array [
+          Object {
+            "Command": Array [
+              "command",
+            ],
+            "EntryPoint": Array [
+              "entrypoint",
+            ],
+            "Environment": Array [
+              Object {
+                "Name": "task",
+                "Value": "variable",
+              },
+            ],
+            "Image": undefined,
+            "LogConfiguration": Object {
+              "LogDriver": "awslogs",
+              "Options": Object {
+                "awslogs-group": Object {
+                  "Fn::Sub": "\${FargateTasksLogGroup}",
+                },
+                "awslogs-region": Object {
+                  "Fn::Sub": "\${AWS::Region}",
+                },
+                "awslogs-stream-prefix": "fargate",
+              },
+            },
+            "Name": "my-task",
+          },
+        ],
+        "Cpu": 256,
+        "ExecutionRoleArn": Object {
+          "Fn::Sub": "\${FargateIamExecutionRole}",
+        },
+        "Family": "my-task",
+        "Memory": "0.5GB",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": Array [
+          "FARGATE",
+        ],
+        "RuntimePlatform": undefined,
+        "Tags": Array [
+          Object {
+            "Key": "task",
+            "Value": "tag",
+          },
+        ],
+        "TaskRoleArn": Object {
+          "Fn::Sub": "\${FargateIamTaskRole}",
+        },
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+  },
+}
+`;

--- a/src/__tests__/__snapshots__/parser.test.js.snap
+++ b/src/__tests__/__snapshots__/parser.test.js.snap
@@ -313,3 +313,67 @@ Object {
   },
 }
 `;
+
+exports[`minimal standalone task configuration 1`] = `
+Object {
+  "architecture": undefined,
+  "cloudFormationResource": Object {
+    "additionalContainers": Array [],
+    "container": Object {},
+    "service": Object {},
+    "task": Object {},
+  },
+  "clusterName": undefined,
+  "containerInsights": undefined,
+  "cpu": 256,
+  "environment": Object {},
+  "executionRoleArn": undefined,
+  "iamManagedPolicies": Array [],
+  "iamRoleStatements": Array [],
+  "logGroupName": undefined,
+  "logRetentionInDays": undefined,
+  "memory": "0.5GB",
+  "tags": Object {},
+  "taskRoleArn": undefined,
+  "tasks": Array [
+    Object {
+      "architecture": undefined,
+      "cloudFormationResource": Object {
+        "additionalContainers": Array [],
+        "container": Object {},
+        "service": Object {},
+        "task": Object {},
+      },
+      "command": Array [],
+      "cpu": 256,
+      "dependsOn": undefined,
+      "entryPoint": Array [],
+      "environment": Object {},
+      "executionRoleArn": undefined,
+      "image": "my-image",
+      "memory": "0.5GB",
+      "name": "my-task",
+      "tags": Object {},
+      "taskRoleArn": undefined,
+      "vpc": Object {
+        "assignPublicIp": false,
+        "securityGroupIds": Array [
+          "sg-1234",
+        ],
+        "subnetIds": Array [
+          "subnet-1234",
+        ],
+      },
+    },
+  ],
+  "vpc": Object {
+    "assignPublicIp": false,
+    "securityGroupIds": Array [
+      "sg-1234",
+    ],
+    "subnetIds": Array [
+      "subnet-1234",
+    ],
+  },
+}
+`;

--- a/src/__tests__/compiler.test.js
+++ b/src/__tests__/compiler.test.js
@@ -147,6 +147,76 @@ test('single scheduled task', () => {
   expect(compiled).toMatchSnapshot();
 });
 
+test('single standalone task', () => {
+  const compiled = compile(
+    {
+      'my-image': 'image-uri',
+    },
+    {
+      clusterName: undefined,
+      containerInsights: undefined,
+      memory: '0.5GB',
+      cpu: 256,
+      architecture: undefined,
+      environment: {
+        provider: 'variable',
+      },
+      iamRoleStatements: [
+        {
+          Effect: 'Allow',
+          Action: ['sqs:*'],
+          Resource: '*',
+        },
+      ],
+      iamManagedPolicies: ['arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess'],
+      vpc: {
+        subnetIds: ['subnet-1234', 'subnet-5678'],
+        securityGroupIds: ['sg-1234'],
+        assignPublicIp: false,
+      },
+      tags: {
+        provider: 'tag',
+      },
+      cloudFormationResource: {
+        task: {},
+        container: {},
+        additionalContainers: [],
+        service: {},
+      },
+      tasks: [
+        {
+          name: 'my-task',
+          image: 'my-image',
+          vpc: {
+            subnetIds: ['subnet-1234', 'subnet-5678'],
+            securityGroupIds: ['sg-1234'],
+            assignPublicIp: false,
+          },
+          command: ['command'],
+          entryPoint: ['entrypoint'],
+          memory: '0.5GB',
+          cpu: 256,
+          architecture: undefined,
+          environment: {
+            task: 'variable',
+          },
+          tags: {
+            task: 'tag',
+          },
+          cloudFormationResource: {
+            task: {},
+            container: {},
+            additionalContainers: [],
+            service: {},
+          },
+        },
+      ],
+    }
+  );
+
+  expect(compiled).toMatchSnapshot();
+});
+
 test('service and scheduled tasks', () => {
   const compiled = compile(
     {

--- a/src/__tests__/parser.test.js
+++ b/src/__tests__/parser.test.js
@@ -33,6 +33,23 @@ test('minimal scheduled task configuration', () => {
   expect(parsed).toMatchSnapshot();
 });
 
+test('minimal standalone task configuration', () => {
+  const parsed = parse({
+    vpc: {
+      securityGroupIds: ['sg-1234'],
+      subnetIds: ['subnet-1234'],
+    },
+    tasks: {
+      'my-task': {
+        image: 'my-image',
+        service: false,
+      },
+    },
+  });
+
+  expect(parsed).toMatchSnapshot();
+});
+
 test('full service task configuration', () => {
   const parsed = parse({
     clusterName: 'my-cluster-name',

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -231,6 +231,19 @@ const compileTask = (images, task) => {
     };
   }
 
+  if (!task.service) {
+    return {
+      Resources: {
+        [identifier + 'Task']: compileTaskDefinition(images, task),
+      },
+      Outputs: {
+        [identifier + 'TaskArn']: {
+          Value: { Ref: identifier + 'Task' },
+        },
+      },
+    };
+  }
+
   return {
     Resources: {
       [identifier + 'Task']: compileTaskDefinition(images, task),

--- a/src/parser.js
+++ b/src/parser.js
@@ -59,6 +59,10 @@ const parseTask = (global, name, task) => {
     };
   }
 
+  if (task.service === false) {
+    return definition;
+  }
+
   const isStrictMode = get(task, 'service.strict', false);
 
   return {

--- a/src/schema.js
+++ b/src/schema.js
@@ -84,13 +84,19 @@ module.exports = {
             tags: { type: 'object' },
             dependsOn: { type: 'array', items: { type: 'string' } },
             service: {
-              type: 'object',
-              properties: {
-                desiredCount: { type: 'integer' },
-                maximumPercent: { type: 'integer' },
-                minimumHealthyPercent: { type: 'integer' },
-                spot: { type: 'boolean' },
-              },
+              anyOf: [
+                {
+                  type: 'object',
+                  properties: {
+                    desiredCount: { type: 'integer' },
+                    maximumPercent: { type: 'integer' },
+                    minimumHealthyPercent: { type: 'integer' },
+                    spot: { type: 'boolean' },
+                    strict: { type: 'boolean' },
+                  },
+                },
+                { const: false },
+              ],
             },
             schedule: { type: 'string' },
             cloudFormationResource: {


### PR DESCRIPTION
Add support for creating ECS TaskDefinitions without automatically provisioning an ECS Service by setting `service: false` on a task. This enables on-demand task execution via Lambda, Step Functions, or manual invocation.

Task types now supported:
- Tasks with `schedule` - TaskDefinition + EventBridge Rule
- Tasks with `service: false` - TaskDefinition only (new)
- Tasks with `service` config - TaskDefinition + ECS Service (existing)

Also fixes missing `strict` property in schema validation. The parser already supported `service.strict` but the schema didn't allow it.

This addresses issues raised in https://github.com/eddmann/serverless-fargate/issues/53